### PR TITLE
fix(HomeViewModel): preserve section order and fix error logging

### DIFF
--- a/Features/Sources/Home/ViewModels/HomeViewModel.swift
+++ b/Features/Sources/Home/ViewModels/HomeViewModel.swift
@@ -46,8 +46,6 @@ final class HomeViewModel {
 
     }
 
-    init() { }
-
     func onAppear() async {
         do {
             let model: UIState.HomeModel = try await loadData(for: category)
@@ -55,7 +53,7 @@ final class HomeViewModel {
                 state = .loaded(model: model)
             }
         } catch {
-            print(ViewModelError.failedToLoad)
+            print(error)
             withAnimation {
                 state = .error
             }
@@ -129,7 +127,7 @@ final class HomeViewModel {
             while let result = try await taskGroup.next() {
                 sections.append(result)
             }
-            return sections
+            return tasks.compactMap { task in sections.first(where: { $0.type == task.type }) }
         }
     }
 


### PR DESCRIPTION
## Summary
- **Bug**: Sections were rendering in non-deterministic order on each load — `withThrowingTaskGroup` returns results in API completion order, not insertion order. Fixed by re-sorting results against the original `sectionTypes` array after collection.
- **Fix**: `print(ViewModelError.failedToLoad)` was swallowing the actual underlying error. Changed to `print(error)`.
- **Cleanup**: Removed redundant `init() { }` — Swift synthesizes it automatically since all properties have default values.

## Test plan
- [ ] Switch between Movies and Series on Home — carousels should appear in the same order every time
- [ ] Trigger a network error — console should now show the actual error description