### PR TITLE
fix(HomeViewModel): bug fixes

### DIFF
--- a/Features/Sources/Home/ViewModels/HomeViewModel.swift
+++ b/Features/Sources/Home/ViewModels/HomeViewModel.swift
@@ -46,8 +46,6 @@ final class HomeViewModel {
 
     }
 
-    init() { }
-
     func onAppear() async {
         do {
             let model: UIState.HomeModel = try await loadData(for: category)
@@ -55,7 +53,7 @@ final class HomeViewModel {
                 state = .loaded(model: model)
             }
         } catch {
-            print(ViewModelError.failedToLoad)
+            print(error)
             withAnimation {
                 state = .error
             }
@@ -129,7 +127,7 @@ final class HomeViewModel {
             while let result = try await taskGroup.next() {
                 sections.append(result)
             }
-            return sections
+            return tasks.compactMap { task in sections.first(where: { $0.type == task.type }) }
         }
     }
 

--- a/Features/Sources/Home/ViewModels/HomeViewModel.swift
+++ b/Features/Sources/Home/ViewModels/HomeViewModel.swift
@@ -127,7 +127,7 @@ final class HomeViewModel {
             while let result = try await taskGroup.next() {
                 sections.append(result)
             }
-            return tasks.compactMap { task in sections.first(where: { $0.type == task.type }) }
+            return sections
         }
     }
 


### PR DESCRIPTION
## Summary
- Fix error logging to print actual error instead of generic `failedToLoad`
- Remove unused `init()`
- Revert section order preservation (back to task group result order)

## Test plan
- [ ] Switch between Movies/Series categories — sections load correctly
- [ ] Trigger a network error — error state shown and logged correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)